### PR TITLE
[pkgs/curlie.yaml] Fix binary name on windows

### DIFF
--- a/pkgs/curlie.yaml
+++ b/pkgs/curlie.yaml
@@ -30,7 +30,7 @@ os_map:
   win:
     name: windows
     ext: tar.gz
-    bin_path: bin
+    bin_path: curlie
 arch_map:
   amd64: amd64
   arm64: arm64


### PR DESCRIPTION
This allows to install curlie on windows, related to change [pull request](https://github.com/candrewlee14/webman/pull/5)
it is necessary to know that in windows "curl" must be installed