### PR TITLE
Add recipe for 'termdbms' Golang-based terminal UI client for SQLite DBs and CSV files.

### DIFF
--- a/pkgs/era.yaml
+++ b/pkgs/era.yaml
@@ -1,0 +1,35 @@
+title: era
+tagline: Clock/stopwatch with rainy theme for terminal
+about: |
+  A rainy-themed clock for the terminal.
+  To run in stopwatch/counter mode use `-c` command-line parameter.
+  See GitHub page for additional configuration information.
+
+git_user: kyoheiu
+git_repo: era
+info_url: https://github.com/[GIT_USER]/[GIT_REPO]
+releases_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/
+source_url: https://github.com/[GIT_USER]/[GIT_REPO]/
+
+base_download_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/download/v[VER]/
+filename_format: era-v[VER]-[ARCH]-[OS]
+version_format: v[VER]
+latest_strategy: github-release # uses most recent github release tag to get the latest version number
+
+is_binary: false
+
+os_map:
+  linux:
+    name: linux
+    ext: tar.xz
+  macos: 
+    name: apple-darwin
+    ext: tar.xz
+  # win: Unsupported
+arch_map:
+  amd64: x86_64
+  arm64: aarch64
+  
+ignore:
+- os: linux
+  arch: arm64

--- a/pkgs/lf.yaml
+++ b/pkgs/lf.yaml
@@ -1,0 +1,45 @@
+title: lf
+tagline: Go-based terminal file manager inspired by ranger.
+about: |
+  Go-based terminal file manager inspired by ranger.
+
+git_user: gokcehan
+git_repo: lf
+info_url: https://github.com/[GIT_USER]/[GIT_REPO]
+releases_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/
+source_url: https://github.com/[GIT_USER]/[GIT_REPO]/
+
+base_download_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/download/[VER]/
+filename_format: lf-[OS]-[ARCH]
+version_format:
+latest_strategy: github-release # uses most recent github release tag to get the latest version number
+
+is_binary: false
+
+os_map:
+  linux:
+    name: linux
+    ext: tar.gz
+  macos: 
+    name: darwin
+    ext: tar.gz
+  win:
+    name: windows
+    ext: zip
+arch_map:
+  amd64: amd64
+  i386: 386
+  arm: arm
+  arm64: arm64
+  
+ignore:
+- os: windows
+  arch: arm64
+- os: macos
+  arch: arm64
+- os: windows
+  arch: arm
+- os: macos
+  arch: arm
+- os: macos
+  arch: i386

--- a/pkgs/pboy.yaml
+++ b/pkgs/pboy.yaml
@@ -1,0 +1,31 @@
+title: pboy
+tagline: Console-based PDF management utility.
+about: |
+  Paperboy (pboy) is lightweight PDF management tool for the command-line.
+  It helps to rename and move files to a specified folder, and it even 
+  gives some filename suggestions by looking at the content and the PDF
+  metadata.
+
+git_user: 2mol
+git_repo: pboy
+info_url: https://github.com/[GIT_USER]/[GIT_REPO]
+releases_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/
+source_url: https://github.com/[GIT_USER]/[GIT_REPO]/
+
+base_download_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/download/[VER]/
+filename_format: pboy-[OS]
+version_format:
+latest_strategy: github-release # uses most recent github release tag to get the latest version number
+
+is_binary: false
+
+os_map:
+  linux:
+    name: linux
+    ext: tar.gz
+  macos: 
+    name: osx
+    ext: tar.gz
+  # win: Unsupported
+arch_map:
+  amd64: 

--- a/pkgs/termdbms.yaml
+++ b/pkgs/termdbms.yaml
@@ -1,0 +1,44 @@
+title: termdbms
+tagline: Golang-based terminal UI client for SQLite DBs and CSV files
+about: |
+  A TUI for viewing and editing databases, written in pure Go, that supports SQLite and CSV files.
+  Features
+  - Run SQL queries and display the results.
+  - Save SQL queries to a clipboard.
+  - Update, delete, or insert with SQL, with undo/redo supported for SQLite.
+  - Automatic JSON formatting in selection/format mode.
+  - Edit multi-line text with Vim-like controls.
+  - Undo/Redo of changes (SQLite only).
+  - Output query results as a CSV file.
+  - Convert CSV file to SQLite database.
+
+git_user: mathaou
+git_repo: termdbms
+info_url: https://github.com/[GIT_USER]/[GIT_REPO]
+releases_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/
+source_url: https://github.com/[GIT_USER]/[GIT_REPO]/
+
+base_download_url: https://github.com/[GIT_USER]/[GIT_REPO]/releases/download/v[VER]/
+filename_format: termdbms_[OS]_[ARCH]
+version_format: v[VER]
+latest_strategy: github-release # uses most recent github release tag to get the latest version number
+
+is_binary: false
+
+os_map:
+  linux:
+    name: linux
+    ext: zip
+    bin_path: build/termdbms_linux_x64
+  macos:
+    name: osx
+    ext: zip
+    bin_path: build/termdbms_osx_x64
+  win:
+    name: windows
+    ext: zip
+    bin_path: build/termdbms_windows_x64
+arch_map:
+  amd64: x64
+  # i386: x86
+  # arm64: Unsupported


### PR DESCRIPTION
**Note**:  `termdbms` application does not have GitHub `latest` flag; installation must be done by explicit version number. For example:
`webman add termdbms@0.9-alpha`

Also, due to the multi-level installation path, I had to disable (remove) support for `i386` architecture.