### PR TITLE
Fix windows extension

### DIFF
--- a/pkgs/jq.webman-pkg.yml
+++ b/pkgs/jq.webman-pkg.yml
@@ -27,6 +27,7 @@ os_map:
     name: osx-amd64
   win:
     name: win64
+    ext: exe
 arch_map:
   amd64: x86_64
   # arm64: Unsupported

--- a/pkgs/tea.webman-pkg.yml
+++ b/pkgs/tea.webman-pkg.yml
@@ -18,10 +18,13 @@ is_binary: true
 os_map:
   linux:
     name: linux
+    ext: xz
   macos:
     name: darwin
+    ext: xz
   win:
     name: windows
+    ext: exe.xz
 arch_map:
   amd64: amd64
   386: "386"


### PR DESCRIPTION
I came across this when I noticed that `tea` offers compressed binary downloads (which speeds it up the download a bit)

Windows didn't work with the "fixes" I made in `webman` because it always wanted to tack on `.exe`. 
Being a bit more familiar with the project, I think the correct fix is to not auto-suffix `.exe` but instead add it to the `os_map` `ext` field when applicable, notably for non-archives.

Let me know if you think this is more correct or if I'm off-base.